### PR TITLE
Use custom css

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -3,5 +3,5 @@ version: '3'
 services:
   ipt_service:
     build: .
-    image: michaltorma/ipt-s3:latest
+    image: gbifnorway/ipt-s3:latest
     platform: linux/amd64

--- a/src/run.sh
+++ b/src/run.sh
@@ -5,5 +5,7 @@ echo "[default]" > ~/.s3cfg
 echo access_key = $S3_ACCESS_KEY >> ~/.s3cfg
 echo secret_key = $S3_SECRET_KEY >> ~/.s3cfg
 s4cmd mb s3://$S3_BUCKET_NAME --endpoint-url $S3_HOST
-s3fs $S3_BUCKET_NAME /srv/ipt -o passwd_file=/root/passwd-s3fs,use_path_request_style,url=$S3_HOST && \
+s3fs $S3_BUCKET_NAME $IPT_DATA_DIR -o passwd_file=/root/passwd-s3fs,use_path_request_style,url=$S3_HOST && \
+    touch ${IPT_DATA_DIR}/config/custom.css && \
+    cp ${IPT_DATA_DIR}/config/custom.css /usr/local/tomcat/webapps/ROOT/styles/custom.css && \
     catalina.sh run


### PR DESCRIPTION
See https://github.com/gbif/ipt/issues/1634 

Having custom.css for the IPT is not supported at the moment, but we can make our own one in our bucket/datadir, and use it to overwrite the custom.css in tomcat webapps. Note $IPT_DATA_DIR is from https://github.com/gbif/ipt/blob/master/package/docker/Dockerfile